### PR TITLE
Variant exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ Use them to do great things. Please share the results!
 ## Usage
 
 ```
-# export Jan 2016 games to lichess_db_2016-01.pgn"
+# export Jan 2016 Standard games to lichess_db_2016-01.pgn
 sbt "run 2016-01"
 
-# export Jan 2016 games to custom_file.pgn"
+# export Jan 2016 Standard games to custom_file.pgn
 sbt "run 2016-01 custom_file.pgn"
+
+# export Jan 2016 Atomic games to custom_file.pgn
+sbt "run 2016-01 custom_file.pgn atomic"
 ```

--- a/export-all.sh
+++ b/export-all.sh
@@ -4,25 +4,34 @@ dir=${1}
 
 export() {
     echo "---------------------------"
-    ./export.sh "$1-$2" $dir
+    ./export-single-variant.sh "$1-$2" $dir $3
 }
 
 echo "Export all to $dir"
 
+variants="standard chess960 antichess atomic crazyhouse horde kingOfTheHill racingKings threeCheck"
+
 for year in 2013; do
   for month in 08 09 10 11 12; do
-    export $year $month
+    for variant in $variants; do
+      echo $variant
+      #export $year $month $variant
+    done
   done
 done
 
 for year in 2014 2015 2016; do
   for month in 01 02 03 04 05 06 07 08 09 10 11 12; do
-    export $year $month
+    for variant in $variants; do
+      export $year $month $variant
+    done
   done
 done
 
 for year in 2017; do
-  for month in 01 02 03 04 05; do
-    export $year $month
+  for month in 01 02 03 04 05 06 07 08 09 10; do
+    for variant in $variants; do
+      export $year $month $variant
+    done
   done
 done

--- a/export-all.sh
+++ b/export-all.sh
@@ -4,12 +4,16 @@ dir=${1}
 
 export() {
     echo "---------------------------"
-    ./export-single-variant.sh "$1-$2" $dir $3
+    ./export-single-variant.sh "$1-$2" $dir/$3 $3
 }
 
 echo "Export all to $dir"
 
 variants="standard chess960 antichess atomic crazyhouse horde kingOfTheHill racingKings threeCheck"
+
+for variant in $variants; do
+  mkdir -p $dir/$variant
+done
 
 for year in 2013; do
   for month in 08 09 10 11 12; do

--- a/export-all.sh
+++ b/export-all.sh
@@ -14,8 +14,7 @@ variants="standard chess960 antichess atomic crazyhouse horde kingOfTheHill raci
 for year in 2013; do
   for month in 08 09 10 11 12; do
     for variant in $variants; do
-      echo $variant
-      #export $year $month $variant
+      export $year $month $variant
     done
   done
 done

--- a/export-all.sh
+++ b/export-all.sh
@@ -2,7 +2,7 @@
 
 dir=${1}
 
-export() {
+export_month() {
     echo "---------------------------"
     ./export-single-variant.sh "$1-$2" $dir/$3 $3
 }
@@ -18,7 +18,7 @@ done
 for year in 2013; do
   for month in 08 09 10 11 12; do
     for variant in $variants; do
-      export $year $month $variant
+      export_month $year $month $variant
     done
   done
 done
@@ -26,7 +26,7 @@ done
 for year in 2014 2015 2016; do
   for month in 01 02 03 04 05 06 07 08 09 10 11 12; do
     for variant in $variants; do
-      export $year $month $variant
+      export_month $year $month $variant
     done
   done
 done
@@ -34,7 +34,7 @@ done
 for year in 2017; do
   for month in 01 02 03 04 05 06 07 08 09 10; do
     for variant in $variants; do
-      export $year $month $variant
+      export_month $year $month $variant
     done
   done
 done

--- a/export-single-variant.sh
+++ b/export-single-variant.sh
@@ -31,11 +31,4 @@ grep -v -F "$bz2file" sha256sums.txt > sha256sums.txt.new || touch sha256sums.tx
 sha256sum "$bz2file" | tee --append sha256sums.txt.new
 mv sha256sums.txt.new sha256sums.txt
 
-cd -
-
-echo "Generating website"
-
-cd web
-nodejs index.js $dir
-
 echo "Done!"

--- a/export-single-variant.sh
+++ b/export-single-variant.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+
+month=${1}
+dir=${2}
+variant=${3}
+file="lichess_db_${variant}_rated_$month.pgn"
+bz2file="$file.bz2"
+
+echo "Export $variant games of $month to $file"
+
+sbt "run $month $dir/$file $variant"
+
+cd "$dir"
+
+echo "Counting games in $bz2file"
+
+touch counts.txt
+grep -v -F "$file" counts.txt > counts.txt.new || touch counts.txt.new
+games=$(grep --count -F '[Site ' "$file")
+echo "$bz2file $games" >> counts.txt.new
+mv counts.txt.new counts.txt
+
+echo "Compressing $games games to $bz2file"
+
+rm -f $bz2file
+bzip2 $file
+
+echo "Check summing $bz2file"
+touch sha256sums.txt
+grep -v -F "$bz2file" sha256sums.txt > sha256sums.txt.new || touch sha256sums.txt.new
+sha256sum "$bz2file" | tee --append sha256sums.txt.new
+mv sha256sums.txt.new sha256sums.txt
+
+cd -
+
+echo "Generating website"
+
+cd web
+nodejs index.js $dir
+
+echo "Done!"

--- a/export.sh
+++ b/export.sh
@@ -15,8 +15,6 @@ for variant in $variants; do
   export_variant $variant
 done
 
-cd -
-
 echo "Generating website"
 
 cd web

--- a/export.sh
+++ b/export.sh
@@ -3,7 +3,7 @@
 month=${1}
 dir=${2}
 
-export() {
+export_variant() {
     echo "---------------------------"
     mkdir -p $dir/$1
     ./export-single-variant.sh $month $dir/$1 $1
@@ -12,7 +12,7 @@ export() {
 variants="standard chess960 antichess atomic crazyhouse horde kingOfTheHill racingKings threeCheck"
 
 for variant in $variants; do
-  export $variant
+  export_variant $variant
 done
 
 cd -

--- a/export.sh
+++ b/export.sh
@@ -5,7 +5,8 @@ dir=${2}
 
 export() {
     echo "---------------------------"
-    ./export-single-variant.sh $month $dir $1
+    mkdir -p $dir/$1
+    ./export-single-variant.sh $month $dir/$1 $1
 }
 
 variants="standard chess960 antichess atomic crazyhouse horde kingOfTheHill racingKings threeCheck"

--- a/export.sh
+++ b/export.sh
@@ -1,40 +1,15 @@
-#!/bin/bash -e
+#!/bin/bash
 
 month=${1}
 dir=${2}
-file="lichess_db_standard_rated_$month.pgn"
-bz2file="$file.bz2"
 
-echo "Export $month to $file"
+export() {
+    echo "---------------------------"
+    ./export-single-variant.sh $month $dir $1
+}
 
-sbt "run $month $dir/$file"
+variants="standard chess960 antichess atomic crazyhouse horde kingOfTheHill racingKings threeCheck"
 
-cd "$dir"
-
-echo "Counting games in $bz2file"
-
-touch counts.txt
-grep -v -F "$file" counts.txt > counts.txt.new || touch counts.txt.new
-games=$(grep --count -F '[Site ' "$file")
-echo "$bz2file $games" >> counts.txt.new
-mv counts.txt.new counts.txt
-
-echo "Compressing $games games to $bz2file"
-
-rm -f $bz2file
-bzip2 $file
-
-echo "Check summing $bz2file"
-touch sha256sums.txt
-grep -v -F "$bz2file" sha256sums.txt > sha256sums.txt.new || touch sha256sums.txt.new
-sha256sum "$bz2file" | tee --append sha256sums.txt.new
-mv sha256sums.txt.new sha256sums.txt
-
-cd -
-
-echo "Generating website"
-
-cd web
-nodejs index.js $dir
-
-echo "Done!"
+for variant in $variants; do
+  export $variant
+done

--- a/export.sh
+++ b/export.sh
@@ -14,3 +14,10 @@ variants="standard chess960 antichess atomic crazyhouse horde kingOfTheHill raci
 for variant in $variants; do
   export $variant
 done
+
+cd -
+
+echo "Generating website"
+
+cd web
+nodejs index.js $dir

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -17,7 +17,7 @@ import reactivemongo.akkastream.{State, cursorProducer}
 import org.joda.time.DateTime
 
 import chess.format.pgn.Pgn
-import chess.variant.Variant
+import chess.variant.{ Standard, Horde, Variant }
 import lichess.DB.BSONDateTimeHandler
 import lila.analyse.Analysis
 import lila.analyse.Analysis.analysisBSONHandler
@@ -33,13 +33,13 @@ object Main extends App {
 
     val path = args.lift(1).getOrElse("out/lichess_db_%.pgn").replace("%", fromStr)
 
-    val variant = Variant.apply(args.lift(2).getOrElse("standard")).getOrElse(throw new RuntimeException("Invalid variant.")).id
+    val variant = Variant.apply(args.lift(2).getOrElse("standard")).getOrElse(throw new RuntimeException("Invalid variant."))
 
     val fromWithoutAdjustments = new DateTime(fromStr).withDayOfMonth(1).withTimeAtStartOfDay()
     val to = fromWithoutAdjustments plusMonths 1
 
     val hordeStartDate = new DateTime(2015, 4, 11, 10, 0)
-    val from = if (variant == 8 && hordeStartDate.compareTo(fromWithoutAdjustments) > 0) hordeStartDate else fromWithoutAdjustments
+    val from = if (variant == Horde && hordeStartDate.compareTo(fromWithoutAdjustments) > 0) hordeStartDate else fromWithoutAdjustments
 
     if (from.compareTo(to) > 0) {
       System.out.println("Too early for Horde games. Exiting.");
@@ -60,7 +60,7 @@ object Main extends App {
 
         val sources = List(S.Lobby, S.Friend, S.Tournament, S.Pool)
 
-        val variantBson = if (variant == 1) BSONDocument("$exists" -> false) else BSONInteger(variant)
+        val variantBson = if (variant == Standard) BSONDocument("$exists" -> false) else BSONInteger(variant.id)
         val query = BSONDocument(
           "ca" -> BSONDocument("$gte" -> from, "$lt" -> to),
           "ra" -> true,

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -30,12 +30,21 @@ object Main extends App {
   override def main(args: Array[String]) {
 
     val fromStr = args.lift(0).getOrElse("2015-01")
-    val from = new DateTime(fromStr).withDayOfMonth(1).withTimeAtStartOfDay()
-    val to = from plusMonths 1
 
     val path = args.lift(1).getOrElse("out/lichess_db_%.pgn").replace("%", fromStr)
 
     val variant = Variant.apply(args.lift(2).getOrElse("standard")).getOrElse(throw new RuntimeException("Invalid variant.")).id
+
+    val fromWithoutAdjustments = new DateTime(fromStr).withDayOfMonth(1).withTimeAtStartOfDay()
+    val to = fromWithoutAdjustments plusMonths 1
+
+    val hordeStartDate = new DateTime(2015, 4, 11, 10, 0)
+    val from = if (variant == 8 && hordeStartDate.compareTo(fromWithoutAdjustments) > 0) hordeStartDate else fromWithoutAdjustments
+
+    if (from.compareTo(to) > 0) {
+      System.out.println("Too early for Horde games. Exiting.");
+      System.exit(0);
+    }
 
     println(s"Export $from to $path")
 

--- a/web/index.html.tpl
+++ b/web/index.html.tpl
@@ -16,8 +16,30 @@
           <h1><a href="https://lichess.org">lichess.org</a> game database</h1>
         </header>
         <hr>
-        <section id="main_content">
+        <div id="selector">
+          <a for="standard_games" class="on">Standard Chess</a>
+          <a for="variant_games">Variants</a>
+        </div>
+        <section id="standard_games" class="panel">
           <!-- table-standard -->
+        </section>
+        <section id="variant_games" class="panel" style="display:none">
+          <h3>Antichess</h3>
+          <!-- table-antichess -->
+          <h3>Atomic</h3>
+          <!-- table-atomic -->
+          <h3>Chess960</h3>
+          <!-- table-chess960 -->
+          <h3>Crazyhouse</h3>
+          <!-- table-crazyhouse -->
+          <h3>Horde</h3>
+          <!-- table-horde -->
+          <h3>King of the Hill</h3>
+          <!-- table-kingOfTheHill -->
+          <h3>Racing Kings</h3>
+          <!-- table-racingKings -->
+          <h3>Three-check</h3>
+          <!-- table-threeCheck -->
         </section>
 
         <br /><br />
@@ -89,27 +111,6 @@
           </p>
         </section>
 
-        <br /><br />
-        <section>
-          <h2>Variant databases</h2>
-          <h3>Antichess</h3>
-          <!-- table-antichess -->
-          <h3>Atomic</h3>
-          <!-- table-atomic -->
-          <h3>Chess960</h3>
-          <!-- table-chess960 -->
-          <h3>Crazyhouse</h3>
-          <!-- table-crazyhouse -->
-          <h3>Horde</h3>
-          <!-- table-horde -->
-          <h3>King of the Hill</h3>
-          <!-- table-kingOfTheHill -->
-          <h3>Racing Kings</h3>
-          <!-- table-racingKings -->
-          <h3>Three-check</h3>
-          <!-- table-threeCheck -->
-        </section>
-
         <footer>
           All games played on <a href="https://lichess.org">lichess.org</a> are in the public domain.<br />
           Are you building something cool with this database? Please let us know!<br />
@@ -118,5 +119,23 @@
 
       </div>
     </div>
+    <script>
+      function doAll(els, f) {
+        Array.prototype.forEach.call(els, f);
+      }
+      var selectors = document.querySelectorAll('#selector a');
+      doAll(selectors, function(el) {
+        el.addEventListener('click', function() {
+          var selected = el.getAttribute('for');
+          doAll(selectors, function(s) {
+            s.className = s === el ? 'on' : '';
+          });
+          doAll(document.querySelectorAll('.panel'), function(panel) {
+            panel.style.display = panel.id === selected ? '' : 'none';
+            console.log(panel);
+          });
+        });
+      });
+    </script>
   </body>
 </html>

--- a/web/index.html.tpl
+++ b/web/index.html.tpl
@@ -17,30 +17,7 @@
         </header>
         <hr>
         <section id="main_content">
-          <p><strong><!-- nbGames --></strong> standard rated games, played on lichess.org, in PGN format.</p>
-
-          <table>
-            <thead>
-              <tr>
-                <th>Date</th>
-                <th class="right">Size</th>
-                <th class="right">Games</th>
-                <th class="center">Clock</th>
-                <th>Download</th>
-              </tr>
-            </thead>
-            <tbody>
-              <!-- files -->
-              <!-- total -->
-            </tbody>
-          </table>
-
-          <br /><br />
-          <p>
-            Here's a plain text <a href="list.txt">download list</a>,
-            and the <a href="sha256sums.txt">SHA256 checksums</a>.
-          </p>
-
+          <!-- table-standard -->
         </section>
 
         <br /><br />
@@ -87,6 +64,7 @@
             In files with <strong>✔ Clock</strong>, real-time games include clock states: <code>[%clk 0:01:00]</code>.<br />
             The <code>WhiteElo</code> and <code>BlackElo</code> tags contain Glicko2 ratings.<br />
             The <code>Round</code> and <code>Date</code> tags are omitted (See <code>UTCDate</code> &amp; <code>UTCTime</code> instead).<br />
+            Variant games (see variant databases below) have a `Variant` tag, for example <code>[Variant "Antichess"]</code>.</br />
           </p>
         </section>
 
@@ -111,6 +89,27 @@
           </p>
         </section>
 
+        <br /><br />
+        <section>
+          <h2>Variant databases</h2>
+          <h3>Antichess</h3>
+          <!-- table-antichess -->
+          <h3>Atomic</h3>
+          <!-- table-atomic -->
+          <h3>Chess960</h3>
+          <!-- table-chess960 -->
+          <h3>Crazyhouse</h3>
+          <!-- table-crazyhouse -->
+          <h3>Horde</h3>
+          <!-- table-horde -->
+          <h3>King of the Hill</h3>
+          <!-- table-kingOfTheHill -->
+          <h3>Racing Kings</h3>
+          <!-- table-racingKings -->
+          <h3>Three-check</h3>
+          <!-- table-threeCheck -->
+        </section>
+
         <footer>
           All games played on <a href="https://lichess.org">lichess.org</a> are in the public domain.<br />
           Are you building something cool with this database? Please let us know!<br />
@@ -119,7 +118,5 @@
 
       </div>
     </div>
-
-
   </body>
 </html>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,46 @@
+{
+  "name": "lichess-db",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "fs-extra": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "3.0.1",
+        "universalify": "0.1.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "jsonfile": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
+    "moment": {
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz",
+      "integrity": "sha1-VtoaLRy/AdOLfhr8McELz6GSkWc="
+    },
+    "pretty-bytes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+      "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+    }
+  }
+}

--- a/web/style.css
+++ b/web/style.css
@@ -1,5 +1,5 @@
 /* http://meyerweb.com/eric/tools/css/reset/ v2.0 | 20110126 License: none (public domain)
-*/
+ */
 html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video { padding: 0; margin: 0; font: inherit; font-size: 100%; vertical-align: baseline; border: 0; }
 
 /* HTML5 display-role reset for older browsers */
@@ -134,4 +134,26 @@ table td a:hover {
 }
 pre {
   font-size: 0.7em;
+}
+
+#selector {
+  display: flex;
+  margin-bottom: 1.5em;
+}
+
+#selector a {
+  cursor: pointer;
+  padding: .5em 1em;
+}
+
+#selector a.on {
+  border-bottom: 3px solid #888;
+}
+
+#standard_games {
+  margin-top: 2em;
+}
+
+#variant_games h3 {
+  margin-top: 2em;
 }

--- a/web/table.html.tpl
+++ b/web/table.html.tpl
@@ -1,0 +1,23 @@
+<p><strong><!-- nbGames --></strong> <!-- variant --> rated games, played on lichess.org, in PGN format.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Date</th>
+      <th class="right">Size</th>
+      <th class="right">Games</th>
+      <th class="center">Clock</th>
+      <th>Download</th>
+    </tr>
+  </thead>
+  <tbody>
+    <!-- files -->
+    <!-- total -->
+  </tbody>
+</table>
+
+<br /><br />
+<p>
+  Here's a plain text <a href="<!-- variant -->/list.txt">download list</a>,
+  and the <a href="<!-- variant -->/sha256sums.txt">SHA256 checksums</a>.
+</p>


### PR DESCRIPTION
* the Scala code takes an extra command-line argument for the variant
* export-single-variant.sh is pretty much the original export.sh, but accepts a variant parameter and _does not generate the website_
* export.sh runs export-single-variant.sh for all variants and then regenerates the website
* the table with the files has been moved to its own template file and is re-used for all variants
* All variant database files (and associated files like the checksums) go in their proper directory. If one of the directories does not contain a single .pgn.bz2 file, then index.js will throw an error -- I did not bother catching this error, because it's unexpected behavior anyway.

Also, I'm not sure what do to about Horde: it had the colors switched when it came to the site. Would this be a problem?
