### PR TITLE
Added link to CrazyAra reposity

### DIFF
--- a/web/index.html.tpl
+++ b/web/index.html.tpl
@@ -119,6 +119,9 @@
               <a href="https://github.com/Ramon-Deniz/ChessData#heatmap-of-chess-moves">Heatmap of Chess Moves</a>
             </li>
             <li>
+              <a href="https://github.com/QueensGambit/CrazyAra">Deep Learning Engine for Crazyhouse </a>
+            </li>
+            <li>
               <a>Your project here</a>
             </li>
           </ul>


### PR DESCRIPTION
Hello,
lichess.org's database was one of the main reasons, why the CrazyAra project was brought to live.
It's the only place currently where there's public Crazyhouse game data available.

There's more information about the data which was used on the wiki-page:
 https://github.com/QueensGambit/CrazyAra/wiki/Supervised-training

Best regards,
QueensGambit
