### PR TITLE
pgn dump initial fen instead of [FEN "?"]

### DIFF
--- a/src/main/scala/lila/game/PgnDump.scala
+++ b/src/main/scala/lila/game/PgnDump.scala
@@ -85,7 +85,7 @@ object PgnDump {
             case UnknownFinish => "Unknown"
           }
         })),
-        if (!game.variant.standardInitialPosition) Some(Tag(_.FEN, initialFen.map(_.value).getOrElse("?"))) else None,
+        if (!game.variant.standardInitialPosition) Some(Tag(_.FEN, initialFen.map(_.value).getOrElse(Forsyth.initial))) else None,
         if (!game.variant.standardInitialPosition) Some(Tag("SetUp", "1")) else None,
         if (game.variant.exotic) Some(Tag(_.Variant, game.variant.name)) else None
       ).flatten

--- a/src/main/scala/lila/game/PgnDump.scala
+++ b/src/main/scala/lila/game/PgnDump.scala
@@ -85,7 +85,7 @@ object PgnDump {
             case UnknownFinish => "Unknown"
           }
         })),
-        if (!game.variant.standardInitialPosition) Some(Tag(_.FEN, initialFen.map(_.value).getOrElse(Forsyth.initial))) else None,
+        if (!game.variant.standardInitialPosition) Some(Tag(_.FEN, initialFen.fold(Forsyth.initial)(_.value))) else None,
         if (!game.variant.standardInitialPosition) Some(Tag("SetUp", "1")) else None,
         if (game.variant.exotic) Some(Tag(_.Variant, game.variant.name)) else None
       ).flatten


### PR DESCRIPTION
Addressing https://lichess.org/forum/lichess-feedback/interesting-bug-or-just-a-documentation-typo--please-check-it-mate-#2: `initialFen == None` does not mean the initial position is unknown (`"?"`).

(same as ornicar/lila@566409642fb815df7b00f4dfc673d5ec6d94be13)