### PR TITLE
provide web-seeded torrents

### DIFF
--- a/export-single-variant.sh
+++ b/export-single-variant.sh
@@ -31,4 +31,7 @@ grep -v -F "$bz2file" sha256sums.txt > sha256sums.txt.new || touch sha256sums.tx
 sha256sum "$bz2file" | tee --append sha256sums.txt.new
 mv sha256sums.txt.new sha256sums.txt
 
+echo "Creating torrent for $bz2file"
+mktorrent --web-seed "https://database.lichess.org/$variant/$bz2file" --piece-length 20 "$bz2file"
+
 echo "Done!"

--- a/web/index.js
+++ b/web/index.js
@@ -20,11 +20,9 @@ function fileInfo(gameCounts, variant, n) {
   return fs.stat(path).then(s => {
     const dateStr = n.replace(/.+(\d{4}-\d{2})\.pgn\.bz2/, '$1');
     const m = moment(dateStr);
-    const shortName = n.replace(/.+(\d{4}-\d{2}.+)$/, '$1');
     const hasClock = m.unix() >= clockSince.unix();
     return {
       name: n,
-      shortName: shortName,
       path: path,
       size: s.size,
       date: m,
@@ -48,7 +46,7 @@ function getFiles(variant) {
   return function(gameCounts) {
     return fs.readdir(sourceDir + '/' + variant).then(items => {
       return Promise.all(
-        items.filter(n => n.includes('.pgn.bz2')).map(n => fileInfo(gameCounts, variant, n))
+        items.filter(n => n.endsWith('.pgn.bz2')).map(n => fileInfo(gameCounts, variant, n))
       );
     }).then(items => items.sort((a, b) => b.date.unix() - a.date.unix()));
   }
@@ -61,7 +59,7 @@ function renderTable(files, variant) {
     <td class="right">${prettyBytes(f.size)}</td>
     <td class="right">${f.games ? numberFormat(f.games) : '?'}</td>
     <td class="center">${f.clock ? '✔' : ''}</td>
-    <td><a href="${variant}/${f.name}">${f.shortName}</a></td>
+    <td><a href="${variant}/${f.name}">.pgn.bz2</a> <span class="sep">/</span> <a href="${variant}/${f.name}.torrent">.torrent</a></td>
     </tr>`;
   }).join('\n');
 }

--- a/web/style.css
+++ b/web/style.css
@@ -90,6 +90,8 @@ pre code { padding: 0; color: #f2f2f2; background-color: #303030; border: none; 
 
 ul, ol, dl { margin-bottom: 20px; }
 
+span.sep { color: #e0e0e0; }
+
 /* COMMON STYLES */
 hr { height: 1px; padding-bottom: 1em; margin-top: 1em; line-height: 1px; background: transparent url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAp0AAAABCAQAAAA2592kAAAASUlEQVR4Aa2SMQ4AIAwCy/8fjYO75jzdOFCblEzmdOIpJ5tpLVySFUkxkdKegK3fOfD75Fck/5CifPlr/Cb607tes32WN4S1bQG4FyUDSe/XhgAAAABJRU5ErkJggg==') 50% 0 no-repeat; border: none; }
 


### PR DESCRIPTION
We can pretty easily provide torrent files, without running extra services or participating as a peer.

Uses web seeding to fall back to http, if no peers are available (I suspect most of the time). Even then, having a torrent file with checksums for each block provides some value.

Torrents for existing exports generated on marta, already.