### PR TITLE
Fix initial FEN for horde and racing king

### DIFF
--- a/src/main/scala/lila/game/PgnDump.scala
+++ b/src/main/scala/lila/game/PgnDump.scala
@@ -102,7 +102,7 @@ object PgnDump {
           }
         )
       ),
-      if (!game.variant.standardInitialPosition) Some(Tag(_.FEN, initialFen.getOrElse(Forsyth.initial)))
+      if (!game.variant.standardInitialPosition) Some(Tag(_.FEN, initialFen.getOrElse(game.variant.initialFen)))
       else None,
       if (!game.variant.standardInitialPosition) Some(Tag("SetUp", "1")) else None,
       if (game.variant.exotic) Some(Tag(_.Variant, game.variant.name)) else None


### PR DESCRIPTION
close https://github.com/ornicar/lichess-db/issues/40

I've found a related issue reported on the lila side: https://github.com/ornicar/lila/issues/9883 so I assume it's been introduced there somehow, but didn't find the exact origin. It seems like `lila/` dir is copy pasted from the original repo, so my guess is that some change to the original `Game` structure were not implemented here. This way of doing seems fragile, not that I see a better way to do.

Given the small size of the impacted files, I think it'd best to reupload fixed version of them, instead of listing as caveat.

Tested exporting horde, racingkings, standard, chess960, fromPosition and atomic games. This change does not add unnecessary FEN tags when not needed.

As a side note I'm not sure why this tag is included since it can already be deduced from the variant tag.